### PR TITLE
Parallel join

### DIFF
--- a/join_bricks.py
+++ b/join_bricks.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+
+"""
+Merge partial brick files into complete bricks
+
+source /project/projectdirs/desi/software/desi_environment.sh
+cd $SCRATCH/desi/code/two_percent_DESI
+salloc -N 4 -p debug
+srun -n 32 -c 3 ./join_bricks.py --indir INDIR --outdir OUTDIR
+"""
+
+from __future__ import absolute_import, division, print_function
+from mpi4py import MPI
+import sys, os
+from glob import glob
+import shutil
+import time
+
+import numpy as np
+import fitsio
+
+def mergetruth(infiles, outfile):
+    outtmp = outfile + '.tmp'
+    if len(infiles) > 1:
+        wavehdr = fitsio.read_header(infiles[0], 'WAVE')
+        fluxhdr = fitsio.read_header(infiles[0], 'FLUX')
+        truthhdr = fitsio.read_header(infiles[0], 'TRUTH')
+
+        wave = [fitsio.read(x, 'WAVE') for x in infiles]
+        flux = [fitsio.read(x, 'FLUX') for x in infiles]
+        truth = [fitsio.read(x, 'TRUTH') for x in infiles]
+
+        fitsio.write(outtmp, wave[0], extname='WAVE', header=wavehdr, clobber=True)
+        fitsio.write(outtmp, np.vstack(flux), header=fluxhdr, extname='FLUX')
+        fitsio.write(outtmp, np.hstack(truth), header=truthhdr, extname='TRUTH')
+    else:
+        shutil.copy(infiles[0], outtmp)
+
+    os.rename(outtmp, outfile)
+
+def mergetargets(infiles, outfile):
+    outtmp = outfile + '.tmp'
+    if len(infiles) > 1:
+        header = fitsio.read_header(infiles[0])
+        targets = [fitsio.read(x, 1) for x in infiles]
+        fitsio.write(outtmp, np.hstack(targets), header=header)
+    else:
+        shutil.copy(infiles[0], outtmp)
+
+    os.rename(outtmp, outfile)
+
+#-------------------------------------------------------------------------
+comm = MPI.COMM_WORLD
+size = comm.Get_size()
+rank = comm.Get_rank()
+
+import optparse
+
+parser = optparse.OptionParser(usage = "%prog [options]")
+parser.add_option("-i", "--indir", type=str,  help="input directory")
+parser.add_option("-o", "--outdir", type=str,  help="output directory")
+
+opts, args = parser.parse_args()
+
+#- Edison defaults for debugging convenience
+if opts.indir is None:
+    opts.indir = '/global/project/projectdirs/desi/users/forero/datachallenge2017/two_percent_DESI'
+
+if opts.outdir is None:
+    opts.outdir = '/scratch2/scratchdirs/sjbailey/desi/dc17a'
+
+#- Build dictionary of files associated with each brickname;
+#- use rank 0 only to not overwhelm disk
+if rank == 0:
+    print('Scanning input truth files', time.asctime())
+    truthfiles = glob(opts.indir+'/output_*/???/truth-*.fits')
+
+    bricks = dict()
+    for filename in truthfiles:
+        brickname = os.path.basename(filename)[6:14]
+        if brickname not in bricks:
+            bricks[brickname] = [filename, ]
+        else:
+            bricks[brickname].append(filename)
+else:
+    bricks = None
+
+#- Broadcast brick dictionary to all ranks
+comm.barrier()
+if rank == 0:
+    print('Broadcasting brick dictionary', time.asctime())
+
+bricks = comm.bcast(bricks, root=0)
+bricknames = sorted(bricks.keys())
+
+#- Create output subdirectories using rank 0 process
+if rank == 0:
+    prefixes = set([b[0:3] for b in bricknames])
+    print('Creating output subdirectories', time.asctime())
+    print('{} prefixes for {} bricks'.format(len(prefixes), len(bricknames)))
+    for p in prefixes:
+        subdir = os.path.join(opts.outdir, p)
+        if not os.path.exists(subdir):
+            os.mkdir(subdir)
+
+#- Start processing bricks
+for i in range(rank, len(bricknames), size):
+    brickname = bricknames[i]
+    subdir = os.path.join(opts.outdir, brickname[0:3])
+
+    print('Rank {}: {}/{} brickname {}'.format(rank, i, len(bricknames), bricknames[i]))
+    truthfiles = bricks[brickname]
+    outtruth = os.path.join(subdir, 'truth-{}.fits'.format(brickname)) 
+    if not os.path.exists(outtruth):
+        mergetruth(truthfiles, outtruth)
+    else:
+        print('    Skipping {}'.format(os.path.basename(outtruth)))
+
+    targetfiles = [x.replace('/truth-', '/targets-') for x in truthfiles]
+    outtargets = os.path.join(subdir, 'targets-{}.fits'.format(brickname)) 
+    if not os.path.exists(outtargets):
+        mergetargets(targetfiles, outtargets)
+    else:
+        print('    Skipping {}'.format(os.path.basename(outtargets)))
+
+    sys.stdout.flush()
+
+#- Wait for everyone to finish
+comm.barrier()
+MPI.Finalize()
+

--- a/join_truth_targets.py
+++ b/join_truth_targets.py
@@ -1,51 +1,123 @@
 #!/usr/bin/env python
-from desitarget import mtl
-import fitsio
-import os
-import desitarget.io as dtio
-from astropy.table import Table, vstack
-import glob
-from argparse import ArgumentParser
-import fitsio
+
+from __future__ import absolute_import, division, print_function
+from mpi4py import MPI
+
+import os, sys, glob, time
+
 import numpy as np
-from astropy.io import fits
+import fitsio
 
-spec_out = False
+def merge_table_data(infiles, ext=1):
+    '''
+    Merge the tables in HDU 1 of a set of input files
+    '''
+    data = [fitsio.read(x, ext) for x in infiles]
+    return np.hstack(data)
 
-dest_dir = 'final_output'
-out_targets = os.path.join(dest_dir,'targets.fits')
-out_truth = os.path.join(dest_dir,'truth.fits')
-out_mtl = os.path.join(dest_dir,'mtl.fits')
+def merge_files(comm, globname, ext, outfile):
+    size = comm.Get_size()
+    rank = comm.Get_rank()
+    if rank == 0:
+        infiles = glob.glob(globname)
+        print('Merging {} files from {}'.format(len(infiles), globname))
+        sys.stdout.flush()
+    else:
+        infiles = None
 
+    infiles = comm.bcast(infiles, root=0)
 
-out_spectra = os.path.join(dest_dir, 'spectra.fits')
-if os.path.isfile(out_spectra):
-    os.remove(out_spectra)
+    #- Each rank reads and combines a different set of files
+    if rank == 0:
+        print('reading', time.asctime())
 
-alltruth = []
-alltargets = []
+    data = merge_table_data(infiles[rank::size], ext=ext)
 
-dirs = glob.glob("output_*")
-for d in dirs:
-    iter_truth = dtio.iter_files(d, 'truth')
-    iter_target = dtio.iter_files(d, 'targets')
-    for truth_file, target_file in zip(iter_truth, iter_target):
-        alltruth.append(Table.read(truth_file))
-        alltargets.append(Table.read(target_file))
+    if rank == 0:
+        print('gathering', time.asctime())
 
-        if spec_out:
-            spec = fitsio.FITS(truth_file)
-            fitsio.write(out_spectra, spec[1][:,:].astype(np.float32))
+    data_tables = comm.gather(data, root=0)
+        
+    #- Recombine and stack at rank 0
+    if rank == 0:
+        print('stacking', time.asctime())
+        data = np.hstack(data_tables)
 
-        print(truth_file, target_file)
+    if rank == 0:
+        print('writing {}'.format(outfile), time.asctime())
+        sys.stdout.flush()
+        header = fitsio.read_header(infiles[0], ext)
+        tmpout = outfile + '.tmp'
+        fitsio.write(tmpout, data, header=header)
+        os.rename(tmpout, outfile)
 
-targets = vstack(alltargets)
-truth = vstack(alltruth)
-mtl = mtl.make_mtl(targets)
+#-------------------------------------------------------------------------
+comm = MPI.COMM_WORLD
+size = comm.Get_size()
+rank = comm.Get_rank()
 
-targets.write(out_targets, overwrite=True)
-truth.write(out_truth, overwrite=True)
-mtl.write(out_mtl, overwrite=True)
+import optparse
+
+parser = optparse.OptionParser(usage = "%prog [options]")
+parser.add_option("-i", "--indir", type=str,  help="input directory")
+parser.add_option("-o", "--outdir", type=str,  help="output directory")
+# parser.add_option("-v", "--verbose", action="store_true", help="some flag")
+
+opts, args = parser.parse_args()
+
+#- Edison defaults for debugging convenience
+if opts.indir is None:
+    opts.indir = '/global/project/projectdirs/desi/users/forero/datachallenge2017/two_percent_DESI'
+
+if opts.outdir is None:
+    opts.outdir = '/scratch2/scratchdirs/sjbailey/desi/dc17a/targets'
+
+#- Cori
+# if opts.indir is None:
+#     opts.indir = '/global/cscratch1/sd/sjbailey/desi/dc17a/scratch/'
+# if opts.outdir is None:
+#     opts.outdir = '/global/cscratch1/sd/sjbailey/desi/dc17a/targets/'
+
+#- Check which outputs still need to be done (in case we had to rerun)
+if rank == 0:
+    todo = dict()
+    todo['sky'] = not os.path.exists(opts.outdir+'/sky.fits')
+    todo['std_dark'] = not os.path.exists(opts.outdir+'/standards-dark.fits')
+    todo['std_bright'] = not os.path.exists(opts.outdir+'/standards-bright.fits')
+    todo['targets'] = not os.path.exists(opts.outdir+'/targets.fits')
+    todo['truth'] = not os.path.exists(opts.outdir+'/truth.fits')
+else:
+    todo = None
+
+todo = comm.bcast(todo, root=0)
+
+if todo['sky']:
+    merge_files(comm, opts.indir+'/output_*/sky.fits', 1, opts.outdir+'/sky.fits')
+
+if todo['std_dark']:
+    merge_files(comm, opts.indir+'/output_*/standards-dark.fits', 1, opts.outdir+'/standards-dark.fits')
+
+if todo['std_bright']:
+    merge_files(comm, opts.indir+'/output_*/standards-bright.fits', 1, opts.outdir+'/standards-bright.fits')
+
+if todo['targets']:
+    merge_files(comm, opts.indir+'/output_*/???/targets-*.fits', 1, opts.outdir+'/targets.fits')
+
+if todo['truth']:
+    merge_files(comm, opts.indir+'/output_*/???/truth-*.fits', 'TRUTH', opts.outdir+'/truth.fits')
+
+MPI.Finalize()
+
+#- MTL (maybe not bother in a parallel job while other cores sit idle?)
+# if rank == 0:
+#     out_mtl = os.path.join(outdir,'mtl.fits')
+#     if not os.path.exists(out_mtl):
+#         from desitarget import mtl
+#         targets = fitsio.read(outdir+'/targets.fits')
+#         mtl = mtl.make_mtl(targets)
+#         tmpout = out_mtl+'.tmp'
+#         fitsio.write(tmpout, mtl)
+#         os.rename(tmpout, out_mtl)
 
 
 


### PR DESCRIPTION
merging my parallel join scripts into master via a pull request to provide some commentary.  Usage:

```
module use /global/common/edison/contrib/desi/modulefiles/
module load desimodules
module swap desitarget/0.11.0
cd $SCRATCH/desi/code/two_percent_DESI

salloc -N 4 -p debug
time srun -n 24 -c 4 ./join_bricks.py \
    --indir /global/project/projectdirs/desi/users/forero/datachallenge2017/two_percent_DESI \
    --outdir $SCRATCH/desi/dc17a/targets

time srun -n 24 -c 4 ./join_truth_targets.py \
    --skydir /global/project/projectdirs/desi/users/forero/datachallenge2017/two_percent_DESI \
    --targetdir $SCRATCH/desi/dc17a/targets \
    --outdir $SCRATCH/desi/dc17a/targets
```
I'm not sure if the `module swap desitarget/0.11.0` was necessary, but I happened to have that when I did this.

`join_bricks.py` ran in 22 minutes.  `join_truth_targets.py` finished everything except MTL (merged target list) in the remaining 8 minutes.  I generated the MTL by hand using the commands at the end of `join_truth_targets.py`, which run in serial anyway.

Both scripts are structured such that if you run out of time and end up with partial output, you can rerun the exact same command in another job and it will pick up where it left off.

`join_bricks.py` merges the partial bricks from Jaime's directories into complete final bricks.  It also reassigns TARGETIDs due to the random seed bug that resulted in multiple subsets having the same TARGETIDs.  It keeps these consistent between the targets\*.fits and truth\*.fits files.

`join_truth_targets.py` generates the omnibus files targets.fits, truth.fits (only catalog, no spectra), standards-dark.fits, standards-bright.fits, sky.fits, and mtl.fits.  To keep the standards-\*.fits TARGETIDs consistent with the other files, this step re-extracts the standards from targets.fits instead of using the original standards\*.fits files in the original output_\* directories.

`join_bricks.py` is pretty specific to this 2% run and its outputs.  `join_truth_targets.py` may have pieces to use in the future.

Implementation note:  I found it tricky to implement an efficient parallel merge of many individual target files into a single file:
* some of the individual pieces were too big to pickle so mpi `comm.gather` and `comm.send` would choke.
* the numpy buffer non-pickle version of `comm.Send` doesn't require pickle, but our target file dtype is too complex for it and it generates a KeyError (I suspect the 2D columns are what it doesn't like but haven't separately verified that; the documentation mentions limitations on the allowable dtypes)
* using pickled `comm.send` in batches to stay within the pickle size limits structurally worked, but the unpickling at the root process became a bottleneck.  It may have been faster than a pure serial version (which took several hours) but I couldn't fit it within a 30 minute debug job even as I went to larger concurrency.
* In the end, it was fastest to have the individual MPI ranks collect up their share of the inputs and then write temporary files, and then have rank 0 read all those back in and combine them to write the final file.  i.e. fitsio via disk was faster than pickling numpy arrays (!).  I'm sure MPI purists are screaming at this point (if they got this far reading this), but that is what is in there now...

On with the sprint!